### PR TITLE
Extract JSON to PB Into Client

### DIFF
--- a/cmd/call/call.go
+++ b/cmd/call/call.go
@@ -8,17 +8,15 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/jhump/protoreflect/desc"
-	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 	"github.com/spf13/cobra"
 	"github.com/wearefair/gurl/pkg/config"
+	"github.com/wearefair/gurl/pkg/jsonpb"
 	"github.com/wearefair/gurl/pkg/k8"
 	"github.com/wearefair/gurl/pkg/log"
 	"github.com/wearefair/gurl/pkg/options"
 	"github.com/wearefair/gurl/pkg/protobuf"
 	"github.com/wearefair/gurl/pkg/util"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -141,20 +139,20 @@ func sendRequest(uri *util.URI, methodDescriptor *desc.MethodDescriptor, message
 	log.Infof("Dialing address: %s", address)
 
 	cfg := &jsonpb.Config{
-		Address: formatAddress(uri),
-		DialOptions: callOptions.DialOptions()...,
+		Address:     formatAddress(uri),
+		DialOptions: callOptions.DialOptions(),
 	}
 
 	client, err := jsonpb.NewClient(cfg)
 	if err != nil {
-		return log.LogAndReturn(err)
+		return nil, log.LogAndReturn(err)
 	}
 
-	response, err := client.Call(callOptions.ContextWithOptions(context.Background(), methodDescriptor, message)
+	response, err := client.Call(callOptions.ContextWithOptions(context.Background()), methodDescriptor, message)
 	if err != nil {
 		return nil, log.LogAndReturn(err)
 	}
-	return responseJSON, nil
+	return response, nil
 }
 
 // Helper func to format an address. Right now, this is only needed because K8

--- a/cmd/call/call.go
+++ b/cmd/call/call.go
@@ -94,7 +94,7 @@ func runCall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Send request and get response
-	response, err := client.Call(callOptions.ContextWithOptions(context.Background()), parsedURI.Service, parsedURI.RPC, data)
+	response, err := client.Call(callOptions.ContextWithOptions(context.Background()), parsedURI.Service, parsedURI.RPC, []byte(data))
 	if err != nil {
 		return log.LogAndReturn(err)
 	}

--- a/cmd/call/call.go
+++ b/cmd/call/call.go
@@ -7,15 +7,12 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/spf13/cobra"
 	"github.com/wearefair/gurl/pkg/config"
 	"github.com/wearefair/gurl/pkg/jsonpb"
 	"github.com/wearefair/gurl/pkg/k8"
 	"github.com/wearefair/gurl/pkg/log"
 	"github.com/wearefair/gurl/pkg/options"
-	"github.com/wearefair/gurl/pkg/protobuf"
 	"github.com/wearefair/gurl/pkg/util"
 	"google.golang.org/grpc/metadata"
 	"k8s.io/client-go/tools/clientcmd"
@@ -71,39 +68,7 @@ func runCall(cmd *cobra.Command, args []string) error {
 	}
 	log.Infof("Parsed URI: %#v", parsedURI)
 
-	// Walks the proto import and service paths defined in the config and returns all descriptors
-	descriptors, err := protobuf.Collect(config.Instance().Local.ImportPaths, config.Instance().Local.ServicePaths)
-	if err != nil {
-		return err
-	}
-
-	// Get the service descriptor that was set in the URI
-	collector := protobuf.NewCollector(descriptors)
-	serviceDescriptor, err := collector.GetService(parsedURI.Service)
-	if err != nil {
-		return err
-	}
-
-	// Find the RPC attached to the service via the URI
-	methodDescriptor := serviceDescriptor.FindMethodByName(parsedURI.RPC)
-	if methodDescriptor == nil {
-		err := fmt.Errorf("No method %s found", parsedURI.RPC)
-		return log.LogAndReturn(err)
-	}
-
-	methodProto := methodDescriptor.AsMethodDescriptorProto()
-	messageDescriptor, err := collector.GetMessage(
-		protobuf.NormalizeMessageName(*methodProto.InputType),
-	)
-	if err != nil {
-		return err
-	}
-
-	message, err := protobuf.Construct(messageDescriptor, data)
-	if err != nil {
-		return err
-	}
-
+	address := fmt.Sprintf("%s:%s", parsedURI.Host, parsedURI.Port)
 	if parsedURI.Protocol == util.K8Protocol {
 		// Set up port forward, then send request
 		req := uriToPortForwardRequest(parsedURI)
@@ -112,14 +77,26 @@ func runCall(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		defer pf.Close()
-		// TODO: Don't mutate the state of the URI and pass it down, that's not great.
-		parsedURI.Port = pf.LocalPort()
+
+		address = fmt.Sprintf("localhost:%s", pf.LocalPort())
+	}
+
+	cfg := &jsonpb.Config{
+		Address:      address,
+		DialOptions:  callOptions.DialOptions(),
+		ImportPaths:  config.Instance().Local.ImportPaths,
+		ServicePaths: config.Instance().Local.ServicePaths,
+	}
+
+	client, err := jsonpb.NewClient(cfg)
+	if err != nil {
+		return log.LogAndReturn(err)
 	}
 
 	// Send request and get response
-	response, err := sendRequest(parsedURI, methodDescriptor, message)
+	response, err := client.Call(callOptions.ContextWithOptions(context.Background()), parsedURI.Service, parsedURI.RPC, data)
 	if err != nil {
-		return err
+		return log.LogAndReturn(err)
 	}
 
 	// Prettifying JSON of response
@@ -130,38 +107,6 @@ func runCall(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Response:\n%s\n", prettyResponse.String())
 	return nil
-}
-
-// sendRequest takes in the uri, the actual method descriptor, and the dynamically constructed message to send
-func sendRequest(uri *util.URI, methodDescriptor *desc.MethodDescriptor, message proto.Message) ([]byte, error) {
-	// TODO: A lot of this logic should get pulled out
-	address := formatAddress(uri)
-	log.Infof("Dialing address: %s", address)
-
-	cfg := &jsonpb.Config{
-		Address:     formatAddress(uri),
-		DialOptions: callOptions.DialOptions(),
-	}
-
-	client, err := jsonpb.NewClient(cfg)
-	if err != nil {
-		return nil, log.LogAndReturn(err)
-	}
-
-	response, err := client.Call(callOptions.ContextWithOptions(context.Background()), methodDescriptor, message)
-	if err != nil {
-		return nil, log.LogAndReturn(err)
-	}
-	return response, nil
-}
-
-// Helper func to format an address. Right now, this is only needed because K8
-// requests get locked to localhost for port-forwarding.
-func formatAddress(uri *util.URI) string {
-	if uri.Protocol == util.K8Protocol {
-		return fmt.Sprintf("localhost:%s", uri.Port)
-	}
-	return fmt.Sprintf("%s:%s", uri.Host, uri.Port)
 }
 
 // Reads K8 config from default location, which is $HOME/.kube/config

--- a/pkg/jsonpb/client.go
+++ b/pkg/jsonpb/client.go
@@ -1,0 +1,52 @@
+package jsonpb
+
+import (
+	"context"
+
+	"github.com/catherinetcai/grpc-gateway/runtime"
+	"github.com/gogo/protobuf/proto"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
+	"google.golang.org/grpc"
+)
+
+// Client handles constructing and dialing a gRPC service
+type Client struct {
+	stub grpcdynamic.Stub
+}
+
+// NewClient creates a client with a Stub
+func NewClient(cfg *Config) (*Client, error) {
+	conn, err := grpc.Dial(cfg.Address, cfg.DialOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		stub: grpcdynamic.NewStub(conn),
+	}, nil
+}
+
+// Call takes in a method descriptor and a proto message and sends it across the wire
+func (c *Client) Call(ctx context.Context, methodDescriptor *desc.MethodDescriptor, message proto.Message) ([]byte, error) {
+	methodProto := methodDescriptor.AsMethodDescriptorProto()
+
+	// TODO: Allow for streaming calls. This locks us to unary calls
+	// Disabled server and client streaming calls
+	disableStreaming := false
+	methodProto.ClientStreaming = &disableStreaming
+	methodProto.ServerStreaming = &disableStreaming
+
+	response, err := c.stub.InvokeRpc(ctx, methodDescriptor, message)
+	if err != nil {
+		return nil, err
+	}
+
+	marshaler := &runtime.JSONPb{}
+	// Marshals PB response into JSON
+	responseJSON, err := marshaler.Marshal(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseJSON, nil
+}

--- a/pkg/jsonpb/client.go
+++ b/pkg/jsonpb/client.go
@@ -37,7 +37,7 @@ func NewClient(cfg *Config) (*Client, error) {
 
 // Call takes in a context, service, RPC, and message as JSON string to convert to protobuf and
 // send across the wire.
-func (c *Client) Call(ctx context.Context, service, rpc, rawMsg string) ([]byte, error) {
+func (c *Client) Call(ctx context.Context, service, rpc string, rawMsg []byte) ([]byte, error) {
 	serviceDescriptor, err := c.collector.GetService(service)
 	if err != nil {
 		return nil, err

--- a/pkg/jsonpb/client.go
+++ b/pkg/jsonpb/client.go
@@ -3,8 +3,8 @@ package jsonpb
 import (
 	"context"
 
-	"github.com/catherinetcai/grpc-gateway/runtime"
 	"github.com/gogo/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 	"google.golang.org/grpc"

--- a/pkg/jsonpb/client.go
+++ b/pkg/jsonpb/client.go
@@ -44,7 +44,7 @@ func (c *Client) Call(ctx context.Context, service, rpc, rawMsg string) ([]byte,
 	}
 
 	// Find the RPC attached to the service via the URI
-	methodDescriptor := serviceDescriptor.FindMethodByName(service)
+	methodDescriptor := serviceDescriptor.FindMethodByName(rpc)
 	if methodDescriptor == nil {
 		err := fmt.Errorf("No method %s found", service)
 		return nil, err

--- a/pkg/jsonpb/client.go
+++ b/pkg/jsonpb/client.go
@@ -2,17 +2,19 @@ package jsonpb
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
+	"github.com/wearefair/gurl/pkg/protobuf"
 	"google.golang.org/grpc"
 )
 
 // Client handles constructing and dialing a gRPC service
 type Client struct {
 	stub grpcdynamic.Stub
+	// TODO: Might want to turn this into an interface?
+	collector *protobuf.Collector
 }
 
 // NewClient creates a client with a Stub
@@ -21,14 +23,45 @@ func NewClient(cfg *Config) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Walks the proto import and service paths defined in the config and returns all descriptors
+	descriptors, err := protobuf.Collect(cfg.ImportPaths, cfg.ServicePaths)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Client{
-		stub: grpcdynamic.NewStub(conn),
+		stub:      grpcdynamic.NewStub(conn),
+		collector: protobuf.NewCollector(descriptors),
 	}, nil
 }
 
-// Call takes in a method descriptor and a proto message and sends it across the wire
-func (c *Client) Call(ctx context.Context, methodDescriptor *desc.MethodDescriptor, message proto.Message) ([]byte, error) {
+// Call takes in a context, service, RPC, and message as JSON string to convert to protobuf and
+// send across the wire.
+func (c *Client) Call(ctx context.Context, service, rpc, rawMsg string) ([]byte, error) {
+	serviceDescriptor, err := c.collector.GetService(service)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the RPC attached to the service via the URI
+	methodDescriptor := serviceDescriptor.FindMethodByName(service)
+	if methodDescriptor == nil {
+		err := fmt.Errorf("No method %s found", service)
+		return nil, err
+	}
+
 	methodProto := methodDescriptor.AsMethodDescriptorProto()
+	messageDescriptor, err := c.collector.GetMessage(
+		protobuf.NormalizeMessageName(*methodProto.InputType),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := protobuf.Construct(messageDescriptor, rawMsg)
+	if err != nil {
+		return nil, err
+	}
 
 	// TODO: Allow for streaming calls. This locks us to unary calls
 	// Disabled server and client streaming calls

--- a/pkg/jsonpb/config.go
+++ b/pkg/jsonpb/config.go
@@ -1,0 +1,11 @@
+package jsonpb
+
+import (
+	"google.golang.org/grpc"
+)
+
+// Config handles everything necessary to construct a Client
+type Config struct {
+	Address     string
+	DialOptions []grpc.DialOption
+}

--- a/pkg/jsonpb/config.go
+++ b/pkg/jsonpb/config.go
@@ -6,6 +6,8 @@ import (
 
 // Config handles everything necessary to construct a Client
 type Config struct {
-	Address     string
-	DialOptions []grpc.DialOption
+	Address      string
+	DialOptions  []grpc.DialOption
+	ImportPaths  []string
+	ServicePaths []string
 }

--- a/pkg/protobuf/proto.go
+++ b/pkg/protobuf/proto.go
@@ -19,11 +19,11 @@ func NormalizeMessageName(name string) string {
 	return strings.TrimLeft(name, ".")
 }
 
-// Construct takes a message descriptor and a message, as a JSON string and
+// Construct takes a message descriptor and a message, as JSON and
 // returns it as a message, or an error if there's issues marshalling
-func Construct(messageDescriptor *desc.MessageDescriptor, request string) (*dynamic.Message, error) {
+func Construct(messageDescriptor *desc.MessageDescriptor, request []byte) (*dynamic.Message, error) {
 	message := dynamic.NewMessage(messageDescriptor)
-	err := (&runtime.JSONPb{}).Unmarshal([]byte(request), message)
+	err := (&runtime.JSONPb{}).Unmarshal(request, message)
 	if err != nil {
 		return nil, log.LogAndReturn(err)
 	}

--- a/pkg/protobuf/proto_test.go
+++ b/pkg/protobuf/proto_test.go
@@ -64,7 +64,7 @@ func TestConstruct(t *testing.T) {
 	}
 
 	// Making an anonymous message struct to convert into a JSON string.
-	messageStr := `{ "name": "cat" }`
+	messageStr := []byte(`{ "name": "cat" }`)
 
 	// Actual construction test here now that we have a real message descriptor.
 	constructed, err := Construct(messageDescriptor, messageStr)
@@ -78,7 +78,7 @@ func TestConstruct(t *testing.T) {
 
 	// Unhappy path - We attempt to marshal a message as JSON string with invalid
 	// field names onto the message. This will construct a message with empty strings.
-	invalidMessageStr := `{ "fake": "news" }`
+	invalidMessageStr := []byte(`{ "fake": "news" }`)
 	invalidMessage, err := Construct(messageDescriptor, invalidMessageStr)
 	if err != nil {
 		t.Errorf("Error constructing message %s", err.Error())


### PR DESCRIPTION
Most of this is lifting a lot of the json to protobuf construction (along with the client) into subpackages that can be re-used. This is in anticipation of `gurl proxy` work to come.