### PR TITLE
[PLAT-725] Updating dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 release/**
 vendor/**
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+.idea
 release/**
 vendor/**
-.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -327,6 +327,14 @@
   revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [[projects]]
+  branch = "v3"
+  digest = "1:229cb0f6192914f518cc1241ede6d6f1f458b31debfa18bf3a5c9e4f7b01e24b"
+  name = "gopkg.in/yaml.v3"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "eeeca48fe7764f320e4870d231902bf9c1be2c08"
+
+[[projects]]
   digest = "1:d89afbf3588e87d2c9e6efdd5528d249b32d23a12fbd7ec324f3cb373c6fb76c"
   name = "k8s.io/api"
   packages = [
@@ -526,7 +534,7 @@
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/metadata",
     "gopkg.in/fatih/set.v0",
-    "gopkg.in/yaml.v2",
+    "gopkg.in/yaml.v3",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime/serializer",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,7 +19,7 @@
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.8.0"
+  version = "1.12.2"
 
 [[constraint]]
   name = "gopkg.in/fatih/set.v0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
   version = "0.1.0"
 
 [[constraint]]
-  branch = "v2"
-  name = "gopkg.in/yaml.v2"
+  branch = "v3"
+  name = "gopkg.in/yaml.v3"
 
 [[override]]
   name = "github.com/docker/distribution"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ func Execute() {
 	}
 }
 
-func Init() {
+func init() {
 	cobra.OnInitialize(initConfig)
 	call.CallCmd.AddCommand(list.ListServicesCmd)
 	call.CallCmd.AddCommand(configcmd.ConfigCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ func Execute() {
 	}
 }
 
-func init() {
+func Init() {
 	cobra.OnInitialize(initConfig)
 	call.CallCmd.AddCommand(list.ListServicesCmd)
 	call.CallCmd.AddCommand(configcmd.ConfigCmd)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/golang/glog"
 	"github.com/wearefair/gurl/pkg/log"


### PR DESCRIPTION
Updating dependencies:
- google.golang.org/grpc from 1.8.0 to 1.12.2
- gopkg.in/yaml.v2 to gopkg.in/yaml.v3